### PR TITLE
Update LICENSE copyright date

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright 2018-2022 Revolution Populi Limited <info@revolutionpopuli.com>, and contributors.
+Copyright 2018-2023 Revolution Populi Limited <info@revolutionpopuli.com>, and contributors.
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
Updating the copyright date from 2022 to 2023.

Github sees a change in the last paragraph, I dont know why.